### PR TITLE
fix: status bar cut off when image is big or zoomed in

### DIFF
--- a/packages/editor-ui/editor-ui.md
+++ b/packages/editor-ui/editor-ui.md
@@ -106,6 +106,8 @@ The editor renders a fixed HTML shell (`renderShell()`) with `data-role` attribu
 - `edit-fieldset` / `save-fieldset` — sidebar panels for editing controls and export settings
 - `rotate-controls` / `crop-controls` — mode-specific control groups within the edit fieldset
 
+The shell is laid out as a five-row grid: top toolbar, tabs, edit toolbar, workspace, and status bar. The workspace row is the only flexible track (`minmax(0, 1fr)`), so zoomed canvases scroll inside the canvas pane instead of pushing the status bar out of view.
+
 **File intake**
 
 Three entry points are supported:

--- a/packages/editor-ui/src/styles.css
+++ b/packages/editor-ui/src/styles.css
@@ -15,7 +15,8 @@
   --grey-grid-a: rgba(63, 54, 41, 0.08);
   --grey-grid-b: rgba(63, 54, 41, 0.03);
   display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  height: 100%;
   min-height: 760px;
   background:
     radial-gradient(circle at top left, rgba(255, 241, 220, 0.9), transparent 34%),
@@ -188,6 +189,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
   min-height: 0;
+  overflow: hidden;
 }
 
 .grey-editor__canvas-pane {


### PR DESCRIPTION
Closes #15 